### PR TITLE
parameter "language" doesn't exist

### DIFF
--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -14,7 +14,6 @@ domain=$(ynh_app_setting_get "$app" domain)
 path=$(ynh_app_setting_get "$app" path)
 admin=$(ynh_app_setting_get "$app" admin)
 is_public=$(ynh_app_setting_get "$app" is_public)
-language=$(ynh_app_setting_get "$app" language)
 
 # Remove trailing "/" for next commands
 path=${path%/}


### PR DESCRIPTION
I looked at jenkins to see why the upgrade fails and noticed this language parameter in the upgrade script.
There is no trace of this paramater in other scripts so I guess it is a copy/paste from another upgrade script ? :)