### PR TITLE
Store composer in /opt

### DIFF
--- a/scripts/backup
+++ b/scripts/backup
@@ -17,7 +17,7 @@ ynh_backup "/var/www/${app}" "sources"
 #
 # TO BE VALIDATED AND TESTED
 ynh_backup "/opt/flarum_composer" "flarum_composer" 
-ynh_backup "/usr/local/bin/composerr" "local_composer" 
+ynh_backup "/usr/local/bin/composer" "local_composer" 
 
 ### MySQL ###
 # If a MySQL database is used:

--- a/scripts/backup
+++ b/scripts/backup
@@ -13,6 +13,12 @@ source /usr/share/yunohost/helpers
 # Note: the last argument is where to save this path, see the restore script.
 ynh_backup "/var/www/${app}" "sources"
 
+# Backup of composer
+#
+# TO BE VALIDATED AND TESTED
+ynh_backup "/opt/flarum_composer" "flarum_composer" 
+ynh_backup "/usr/local/bin/composerr" "local_composer" 
+
 ### MySQL ###
 # If a MySQL database is used:
 # # Dump the database

--- a/scripts/install
+++ b/scripts/install
@@ -43,9 +43,9 @@ sudo chown -R www-data:www-data $tmp
 sudo chmod -R 755 $tmp
 
 # Prepare composer and cache directories
-sudo mkdir -p /var/www/.composer/cache
-sudo chown -R www-data:www-data /var/www/.composer
-sudo chmod -R 755 /var/www/.composer
+sudo mkdir -p /opt/flarum_composer/cache
+sudo chown -R www-data:www-data /opt/flarum_composer
+sudo chmod -R 755 /opt/flarum_composer
 
 ### composer ###
 if ! type "composer" > /dev/null; then
@@ -55,7 +55,7 @@ if ! type "composer" > /dev/null; then
   ACTUAL_SIGNATURE=$(php -r "echo hash_file('SHA384', '$tmp/composer-setup.php');")
   if [ "$EXPECTED_SIGNATURE" = "$ACTUAL_SIGNATURE" ]
   then
-      sudo su - root -c "grep -q -F 'env[COMPOSER_HOME]= /var/www/.composer' /etc/php5/fpm/php-fpm.conf || sudo echo 'env[COMPOSER_HOME]= /var/www/.composer' >> /etc/php5/fpm/php-fpm.conf"
+      sudo su - root -c "grep -q -F 'env[COMPOSER_HOME]= /opt/flarum_composer' /etc/php5/fpm/php-fpm.conf || sudo echo 'env[COMPOSER_HOME]= /opt/flarum_composer' >> /etc/php5/fpm/php-fpm.conf"
       sudo service php5-fpm reload
       sudo su - www-data -s /bin/bash -c "php $tmp/composer-setup.php --install-dir=$tmp --filename=composer"
       sudo mv $tmp/composer /usr/local/bin

--- a/scripts/remove
+++ b/scripts/remove
@@ -12,6 +12,8 @@ domain=$(ynh_app_setting_get "$app" domain)
 # Remove sources
 sudo rm -rf /tmp/composerinstall
 sudo rm -rf /var/www/$app
+sudo rm -rf /opt/flarum_composer
+sudo rm -rf /usr/local/bin/composer
 
 # Remove nginx configuration file
 sudo rm -f /etc/nginx/conf.d/$domain.d/$app.conf

--- a/scripts/restore
+++ b/scripts/restore
@@ -24,6 +24,13 @@ sudo yunohost app checkurl "${domain}${path}" -a "$app" \
 src_path="/var/www/${app}"
 sudo cp -a ./sources "$src_path"
 
+# Restore composer
+#
+# TO BE TESTED AND VALIDATED
+#
+cp -a ./flarum_composer /opt/flarum_composer
+cp -a ./local_composer /usr/local/bin/composer
+
 # Restore permissions to app files
 # you may need to make some file and/or directory writeable by www-data (nginx user)
 sudo chown -R root: "$src_path"


### PR DESCRIPTION
No need to "hide" composer in /var/www/.composer ==> You can place it in /opt for example
Easier to remember and to clean afterwards.
Other adjustments may be required in your script !