### PR TITLE
Better handling of version numbers

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,3 +1,7 @@
+# Version numbers
+flarum_version="0.1.0-beta.7"
+ssowat_ext_ver="*@dev"
+
 # Execute a command as another user
 # usage: exec_as USER COMMAND [ARG ...]
 exec_as() {

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,6 +1,6 @@
 # Version numbers
-flarum_version="0.1.0-beta.7"
-ssowat_ext_ver="*@dev"
+flarum_version="0.1.0-beta.7.1"
+ssowat_ext_ver="0.5"
 
 # Execute a command as another user
 # usage: exec_as USER COMMAND [ARG ...]
@@ -69,7 +69,7 @@ install_and_activate_extension() {
 	local new_extensions_enabled
 
 	# Install extension
-	exec_composer $AS_USER $WORKDIR "require $EXTENSION --ansi -d $WORKDIR"
+	exec_composer $AS_USER $WORKDIR "require $EXTENSION -n --ansi -d $WORKDIR"
 
 	# Retrieve current extensions
 	sql_command="SELECT \`value\` FROM settings WHERE \`key\` = 'extensions_enabled'"

--- a/scripts/backup
+++ b/scripts/backup
@@ -50,6 +50,7 @@ ynh_backup "/etc/nginx/conf.d/$domain.d/$app.conf"
 #=================================================
 
 ynh_backup "/etc/php5/fpm/pool.d/$app.conf"
+ynh_backup "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # BACKUP THE MYSQL DATABASE

--- a/scripts/install
+++ b/scripts/install
@@ -101,7 +101,10 @@ sudo chown -R $app:www-data $tmp
 sudo chmod -R 0775 $tmp
 
 # Install Flarum
-exec_composer $app $final_path "create-project flarum/flarum $tmp $flarum_version --stability=beta --ansi -d $tmp"
+# First, create the project with core and all basic extensions
+exec_composer $app $final_path "create-project flarum/flarum $tmp --stability=beta --ansi -d $tmp"
+# Let's fix the core version by explicitely requiring it
+exec_composer $app $final_path "require flarum/core:$flarum_version -n --ansi -d $tmp"
 
 # Copy Flarum to working directory and clean temp directory
 sudo cp -Rf $tmp/* $final_path
@@ -204,7 +207,7 @@ sql_command="REPLACE INTO \`settings\` (\`key\`, \`value\`) VALUES
   ('mail_port', '587');"
 ynh_mysql_execute_as_root "$sql_command" $db_name
 
-# Install and active the SSOwat auth extension
+# Install and activate the SSOwat auth extension
 install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
 # Configure SSOwat auth extension
 ssowatdomain=$(</etc/yunohost/current_host)

--- a/scripts/install
+++ b/scripts/install
@@ -40,8 +40,6 @@ admin=$YNH_APP_ARG_ADMIN
 title=$YNH_APP_ARG_TITLE
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
-flarum_version="v0.1.0-beta.7"
-ssowat_ext_ver="*@dev"
 bazaar_extension=$YNH_APP_ARG_BAZAAR_EXTENSION
 
 #===================================================

--- a/scripts/install
+++ b/scripts/install
@@ -70,6 +70,7 @@ ynh_app_setting_set $app is_public $is_public
 ynh_app_setting_set $app language $language
 ynh_app_setting_set $app final_path $final_path
 ynh_app_setting_set $app flarum_version $flarum_version
+ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver
 ynh_app_setting_set $app bazaar_extension $bazaar_extension
 
 #===================================================

--- a/scripts/restore
+++ b/scripts/restore
@@ -78,6 +78,7 @@ chmod -R 0775 $final_path
 #=================================================
 
 ynh_restore_file "/etc/php5/fpm/pool.d/$app.conf"
+ynh_restore_file "/etc/php5/fpm/conf.d/20-$app.ini"
 
 #=================================================
 # RESTORE THE LOGROTATE CONFIGURATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -42,6 +42,7 @@ final_path=$(ynh_app_setting_get "$app" final_path)
 db_name=$(ynh_app_setting_get $app db_name)
 db_pwd=$(ynh_app_setting_get $app db_pwd)
 old_flarum_version=$(ynh_app_setting_get "$app" flarum_version)
+old_ssowat_ext_ver=$(ynh_app_setting_get "$app" ssowat_ext_ver)
 bazaar_extension=$(ynh_app_setting_get "$app" bazaar_extension)
 
 #=================================================
@@ -123,12 +124,15 @@ else
 	echo "Flarum doesn't need any update, let's check the extension."
 fi
 
-# Install and activate the SSOwat auth extension
-install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
-# Configure SSOwat auth extension
-ssowatdomain=$(</etc/yunohost/current_host)
-sql_command="INSERT IGNORE INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
-ynh_mysql_execute_as_root "$sql_command" $db_name
+# Check if upgrade of SSOwat extension is needed
+if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver) ]] || [ -z $old_ssowat_ext_ver] ; then
+	# Install and activate the SSOwat auth extension
+	install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
+	# Configure SSOwat auth extension
+	ssowatdomain=$(</etc/yunohost/current_host)
+	sql_command="INSERT IGNORE INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
+	ynh_mysql_execute_as_root "$sql_command" $db_name
+fi
 
 if [[ $bazaar_extension ]]; then
    install_and_activate_extension $app $final_path $db_name "flagrow/bazaar" "flagrow-bazaar"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -111,7 +111,7 @@ fi
 #=================================================
 
 # Downward compatibility: remove the v before version number
-if [[ $old_flarum_version == "v*" ]] then $old_flarum_version = ${old_flarum_version:1}; fi
+if [[ $old_flarum_version == "v*" ]]; then $old_flarum_version = ${old_flarum_version:1}; fi
 # Check if upgrade of Flarum core is needed
 if [[ dpkg --compare-version $old_flarum_version lt $flarum_version ]]; then
 	# Upgrade Flarum

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,7 +112,7 @@ fi
 # FLARUM UPGRADE
 #=================================================
 
-if [[ $old_flarum_version = $flarum_version ]]; then
+if [[ $old_flarum_version -ne $flarum_version ]]; then
 	# Upgrade Flarum
 	exec_composer $app $final_path "update --ansi"
 	pushd $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -137,11 +137,11 @@ fi
 
 # Bug in Nginx with locations and aliases (see http://stackoverflow.com/a/35102259 )
 if [ $path_url = "/" ]; then
-  sed -i "s@__LOCATION_HACK__@@g" ../conf/nginx.conf
-  sed -i "s@__PATH_HACK__@/@g" ../conf/nginx.conf
+  ynh_replace_string "__LOCATION_HACK__" "" "../conf/nginx.conf"
+  ynh_replace_string "__PATH_HACK__" "/" "../conf/nginx.conf"
 else
-  sed -i "s@__LOCATION_HACK__@$path_url@g" ../conf/nginx.conf
-  sed -i "s@__PATH_HACK__@$path_url$path_url@g" ../conf/nginx.conf
+  ynh_replace_string "__LOCATION_HACK__" "$path_url" "../conf/nginx.conf"
+  ynh_replace_string "__PATH_HACK__" "$path_url$path_url" "../conf/nginx.conf"
 fi
 
 # Create a dedicated nginx config

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -112,7 +112,7 @@ fi
 # FLARUM UPGRADE
 #=================================================
 
-if [[ $old_flarum_version -ne $flarum_version ]]; then
+if [[ $old_flarum_version = $flarum_version ]]; then
 	# Upgrade Flarum
 	exec_composer $app $final_path "update --ansi"
 	pushd $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -113,7 +113,7 @@ fi
 # Downward compatibility: remove the v before version number
 if [[ $old_flarum_version == "v*" ]]; then $old_flarum_version = ${old_flarum_version:1}; fi
 # Check if upgrade of Flarum core is needed
-if [[ dpkg --compare-version $old_flarum_version lt $flarum_version ]]; then
+if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version) ]]; then
 	# Upgrade Flarum
 	exec_composer $app $final_path "require -n flarum/core:'$flarum_version'"
 	pushd $final_path

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -42,8 +42,6 @@ final_path=$(ynh_app_setting_get "$app" final_path)
 db_name=$(ynh_app_setting_get $app db_name)
 db_pwd=$(ynh_app_setting_get $app db_pwd)
 old_flarum_version=$(ynh_app_setting_get "$app" flarum_version)
-flarum_version="v0.1.0-beta.7"
-ssowat_ext_ver="*@dev"
 bazaar_extension=$(ynh_app_setting_get "$app" bazaar_extension)
 
 #=================================================
@@ -204,4 +202,9 @@ fi
 
 systemctl reload nginx
 
+#===================================================
+# STORE SETTINGS
+#===================================================
+
 ynh_app_setting_set $app flarum_version $flarum_version
+ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -110,9 +110,12 @@ fi
 # FLARUM UPGRADE
 #=================================================
 
-if [[ $old_flarum_version -ne $flarum_version ]]; then
+# Downward compatibility: remove the v before version number
+if [[ $old_flarum_version == "v*" ]] then $old_flarum_version = ${old_flarum_version:1}; fi
+# Check if upgrade of Flarum core is needed
+if [[ dpkg --compare-version $old_flarum_version lt $flarum_version ]]; then
 	# Upgrade Flarum
-	exec_composer $app $final_path "update --ansi"
+	exec_composer $app $final_path "require -n flarum/core:'$flarum_version'"
 	pushd $final_path
 	exec_as $app php flarum cache:clear
 	popd
@@ -120,7 +123,7 @@ else
 	echo "Flarum doesn't need any update, let's check the extension."
 fi
 
-# Update SSOwat extension
+# Install and activate the SSOwat auth extension
 install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
 # Configure SSOwat auth extension
 ssowatdomain=$(</etc/yunohost/current_host)


### PR DESCRIPTION
Version numbers for `flarum/core` and ssowat extension are now stored globally in `_common.sh` and in app settings.

Both versions are compared to current ones in `upgrade`, and updated if needed.