### PR TITLE
[fix] Install extensions

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,6 +1,6 @@
 # Version numbers
 flarum_version="0.1.0-beta.7.1"
-ssowat_ext_ver="0.5"
+ssowat_ext_ver="0.6"
 
 # Execute a command as another user
 # usage: exec_as USER COMMAND [ARG ...]

--- a/scripts/install
+++ b/scripts/install
@@ -226,7 +226,7 @@ case $language in
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name
     ;;
-  esac
+esac
 
 if [ $bazaar_extension -eq 1 ]; then
   exec_composer $app $final_path "require flagrow/bazaar --ansi"

--- a/scripts/install
+++ b/scripts/install
@@ -228,7 +228,7 @@ case $language in
     ;;
   esac
 
-if [[ $bazaar_extension ]]; then
+if [ $bazaar_extension -eq 1 ]; then
   exec_composer $app $final_path "require flagrow/bazaar --ansi"
 fi
 

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -125,7 +125,7 @@ else
 fi
 
 # Check if upgrade of SSOwat extension is needed
-if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver) ]] || [ -z $old_ssowat_ext_ver] ; then
+if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver && echo true) || -z $old_ssowat_ext_ver ]]; then
 	# Install and activate the SSOwat auth extension
 	install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
 	# Configure SSOwat auth extension
@@ -134,7 +134,7 @@ if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver) ]] || [ 
 	ynh_mysql_execute_as_root "$sql_command" $db_name
 fi
 
-if [[ $bazaar_extension ]]; then
+if [ $bazaar_extension -eq 1 ]; then
    install_and_activate_extension $app $final_path $db_name "flagrow/bazaar" "flagrow-bazaar"
 fi
 


### PR DESCRIPTION
## Problem
- SSOwat extension was recently updated to version 0.6, flarum_ynh did not require it yet.
- Test for SSOwat extension upgrade is badly written
- Bazaar extension is always installed, whatever one specifies in the installation field.

## Solution
- Variable in `_common.sh` for SSOwat extension is now `0.6`
- `dpkg --compare-versions` now explicitly outputs `true` if successful. `$old_ssowat_ext_ver` test included in `[[ ... ]]`.
- `$bazaar_extension` test is now : `if [ $bazaar_extension -eq 1 ];` instead of `if [[ $bazaar_extension ]];`
Fixes #101 

## PR Status
Work finished.
Basic tests and upgrade from last version OK.  
Can be reviewed and tested.