### PR TITLE
Add issue template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,42 @@
+---
+name: Bug report
+about: Create a report to help us debug
+
+---
+
+**How to post a meaningful bug report**
+1. *Read this whole template first.*
+2. *Determine if you are on the right place:*
+   - *If you were performing an action on the app from the webadmin or the CLI (install, update, backup, restore, change url...), you are on the right place!*
+   - *If the issue is about logging in and out of the forum, it is most likely due to the SSOwat extension. Please post the issue on its [repository](https://github.com/tituspijean/flarum-ext-auth-ssowat/issue).*
+   - *Otherwise, the issue may be due to Flarum itself. Refer to its [forum](https://discuss.flarum.org) for help.*
+   - *If you have a doubt, post here, we will figure it out together.*
+3. *Delete the italic comments as you write over them below, and remove this guide.*
+--- 
+
+**Describe the bug**
+*A clear and concise description of what the bug is.*
+
+**Versions**
+- YunoHost version:
+- Package version/branch: *if you did not specify anything, put "latest"*
+
+**To Reproduce**
+*Steps to reproduce the behavior.*
+- *If you performed a command from the CLI, the command itself is enough. For example:*
+    ```sh
+    sudo yunohost app install flarum
+    ```
+- *If you used the webadmin, please perform the equivalent command from the CLI first.*
+- *If the error occurs in your browser, explain what you did:*
+   1. *Go to '...'*
+   2. *Click on '....'*
+   3. *Scroll down to '....'*
+   4. *See error*
+
+**Expected behavior**
+*A clear and concise description of what you expected to happen. You can remove this section if the command above is enough to understand your intent.*
+
+**Logs**
+*Perform the command again with `--debug | tee flarum.log` at the end. The log will be available in the `flarum.log` file. Remove any personal information and credentials, and copy and paste it here in a code block. If the log is long, you can use the [YunoPaste](https://paste.yunohost.org) service.*
+*If applicable and useful, add screenshots to help explain your problem.*

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -38,5 +38,5 @@ about: Create a report to help us debug
 *A clear and concise description of what you expected to happen. You can remove this section if the command above is enough to understand your intent.*
 
 **Logs**
-*Perform the command again with `--debug | tee flarum.log` at the end. The log will be available in the `flarum.log` file. Remove any personal information and credentials, and copy and paste it here in a code block. If the log is long, you can use the [YunoPaste](https://paste.yunohost.org) service.*
+*After a failed command, YunoHost makes the log available to you, but also to others, thanks to `yunohost log display [log name] --share`. The actual command, with the correct log name, is displayed at the end of the failed attempt in the CLI. Execute it and copy here the share link it outputs.*
 *If applicable and useful, add screenshots to help explain your problem.*


### PR DESCRIPTION
## Problem
- Users may be at loss about how to describe their issue and how to report bugs.

## Solution
- To help us help them help us all (*à la* GLaDOS), I propose a simple issue template that guides the user. It first directs them between this repo, the SSOwat extension's and Flarum florum. Then important information and how to get them are listed.

## PR Status
- [x] Work finished.
- [x] Can be reviewed and tested.

## Validation
---
*Minor decision*
- [x] **Code review** : frju365
- [x] **Approval (LGTM)** : frju365
- [ ] **Approval (LGTM)** : 