### PR TITLE
Upgrade to version 0.1.0-beta.7.2

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,5 +1,5 @@
 # Version numbers
-flarum_version="0.1.0-beta.7.1"
+flarum_version="0.1.0-beta.7.2"
 ssowat_ext_ver="0.6"
 
 # Execute a command as another user

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,14 +114,20 @@ fi
 # Downward compatibility: remove the v before version number
 if [[ $old_flarum_version == "v*" ]]; then $old_flarum_version = ${old_flarum_version:1}; fi
 # Check if upgrade of Flarum core is needed
-if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version) ]]; then
+if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version && echo true) ]]; then
 	# Upgrade Flarum
-	exec_composer $app $final_path "require -n flarum/core:'$flarum_version'"
+	exec_composer $app $final_path "require -n flarum/core:$flarum_version"
+	# Database password has to be input on admin page after upgrade to 0.1.0-beta.7.2
+	if [[ $flarum_version == "0.1.0-beta.7.2"]]; then
+		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd"
+	fi
 	pushd $final_path
 	exec_as $app php flarum cache:clear
 	popd
+	upgraded_flarum=true
 else
-	echo "Flarum doesn't need any update, let's check the extension."
+	echo "Flarum does not need to be updated."
+	upgraded_flarum=false
 fi
 
 # Check if upgrade of SSOwat extension is needed
@@ -132,6 +138,10 @@ if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver && echo t
 	ssowatdomain=$(</etc/yunohost/current_host)
 	sql_command="INSERT IGNORE INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
 	ynh_mysql_execute_as_root "$sql_command" $db_name
+	upgraded_ssowat=true
+else
+	echo "SSOwat extension does not need to be updated."
+        upgraded_ssowat=false
 fi
 
 if [ $bazaar_extension -eq 1 ]; then
@@ -213,5 +223,9 @@ systemctl reload nginx
 # STORE SETTINGS
 #===================================================
 
-ynh_app_setting_set $app flarum_version $flarum_version
-ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver
+if [ $upgraded_flarum ]; then
+	ynh_app_setting_set $app flarum_version $flarum_version
+fi
+if [ $upgraded_ssowat ]; then
+	ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver
+fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -118,8 +118,8 @@ if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version && echo t
 	# Upgrade Flarum
 	exec_composer $app $final_path "require -n flarum/core:$flarum_version"
 	# Database password has to be input on admin page after upgrade to 0.1.0-beta.7.2
-	if [[ $flarum_version == "0.1.0-beta.7.2"]]; then
-		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd"
+	if [[ $flarum_version == "0.1.0-beta.7.2" ]]; then
+		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd" -k
 	fi
 	pushd $final_path
 	exec_as $app php flarum cache:clear


### PR DESCRIPTION
Closes #108. This is a security upgrade.

While testing, I discovered some overlooks in the `upgrade` script that I fixed:
- check that upgrade actually occurred before upgrading the app's parameters
- fix the test logic for Flarum (was already fixed for the extension, we forgot to implement it some lines above)

Official documentation about this security fix requires the user to manually enter the password database in the `/admin` page. As it consists in a simple `POST` action, I used a `curl` call to automatically perform it.
⚠️ However, to perform this `curl` call with auto-signed certificates, I had to add the `-k` (accept all certificates) to the command. I consider the risk low, as the `$domain` `curl` reaches to is hosted by the same server.