### PR TITLE
 [enh/fix] Use ynh_print_* helpers / Upgrade to 0.1.0-beta.7.2 and fix upgrade tests

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -26,10 +26,11 @@ exec_composer() {
   # Do not run composer as root
   if [ $AS_USER = "root" ] ; then ynh_die "Do not run composer as root" ; fi
 	pushd "${WORKDIR}"
-	exec_as "$AS_USER" COMPOSER_HOME="${WORKDIR}/.composer" \
+	ynh_exec_warn_less \
+              "exec_as "$AS_USER" COMPOSER_HOME="${WORKDIR}/.composer" \
 		php -d memory_limit=-1 \
 		"${WORKDIR}/composer.phar" $@ \
-		--quiet --no-interaction
+		--no-interaction"
 	popd
 }
 
@@ -44,8 +45,8 @@ init_composer() {
 
 	# install composer
 	curl -sS https://getcomposer.org/installer \
-		| COMPOSER_HOME="${WORKDIR}/.composer" \
-		php -- --quiet --install-dir="$WORKDIR" \
+		| ynh_exec_warn_less \
+		"COMPOSER_HOME="${WORKDIR}/.composer" php -- --install-dir="$WORKDIR"" \
 		|| ynh_die "Unable to install Composer"
 	chmod +x "${WORKDIR}/composer.phar"
 	# update dependencies to create composer.lock

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -1,5 +1,5 @@
 # Version numbers
-flarum_version="0.1.0-beta.7.1"
+flarum_version="0.1.0-beta.7.2"
 ssowat_ext_ver="0.6"
 
 # Execute a command as another user

--- a/scripts/install
+++ b/scripts/install
@@ -101,6 +101,7 @@ sudo chown -R $app:www-data $tmp
 sudo chmod -R 0775 $tmp
 
 # Install Flarum
+ynh_print_info "Composer is installing Flarum and its dependencies. It may take a while..."
 # First, create the project with core and all basic extensions
 exec_composer $app $final_path "create-project flarum/flarum $tmp --stability=beta --ansi -d $tmp"
 # Let's fix the core version by explicitely requiring it
@@ -111,6 +112,7 @@ sudo cp -Rf $tmp/* $final_path
 sudo chown -R $app:www-data $final_path
 sudo chmod -R 0775 $final_path
 ynh_secure_remove $tmp
+ynh_print_info "   ... done!"
 
 #=================================================
 # CREATE A MYSQL DATABASE
@@ -175,6 +177,7 @@ systemctl reload nginx
 # FLARUM POST-INSTALL
 #=================================================
 
+ynh_print_info "Configuring Flarum..."
 # Copy the configuration.yml to working directory
 finalflarumconf="$final_path/configuration.yml"
 cp ../conf/configuration.yml $finalflarumconf
@@ -206,6 +209,7 @@ sql_command="REPLACE INTO \`settings\` (\`key\`, \`value\`) VALUES
   ('mail_host', 'localhost'),
   ('mail_port', '587');"
 ynh_mysql_execute_as_root "$sql_command" $db_name
+ynh_print_info "   ... done!"
 
 # Install and activate the SSOwat auth extension
 install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext-auth-ssowat:$ssowat_ext_ver" "tituspijean-auth-ssowat"
@@ -213,6 +217,7 @@ install_and_activate_extension $app $final_path $db_name "tituspijean/flarum-ext
 ssowatdomain=$(</etc/yunohost/current_host)
 sql_command="INSERT INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
 ynh_mysql_execute_as_root "$sql_command" $db_name
+ynh_print_info "SSOwat extension has been installed."
 
 # Install, activate and set language extensions
 case $language in
@@ -220,21 +225,24 @@ case $language in
     install_and_activate_extension $app $final_path $db_name "milescellar/flarum-ext-french" "milescellar-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name
+    ynh_print_info "French language has been installed."
     ;;
   de)
     install_and_activate_extension $app $final_path $db_name "cbmainz/flarum-de" "cbmainz-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name
+    ynh_print_info "German language has been installed."
     ;;
 esac
 
 if [ $bazaar_extension -eq 1 ]; then
   exec_composer $app $final_path "require flagrow/bazaar --ansi"
+  ynh_print_info "Bazaar extension has been installed."
 fi
 
 # Send login credentials to admin
 app_message="User : $admin, password : $admin_pwd
 Change your password!
 Your forum is accessible at https://$domain$path_url"
->&2 echo $app_message
 ynh_send_readme_to_admin "$app_message" "$admin"
+ynh_print_warn "$app_message"

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -114,14 +114,20 @@ fi
 # Downward compatibility: remove the v before version number
 if [[ $old_flarum_version == "v*" ]]; then $old_flarum_version = ${old_flarum_version:1}; fi
 # Check if upgrade of Flarum core is needed
-if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version) ]]; then
+if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version && echo true) ]]; then
 	# Upgrade Flarum
-	exec_composer $app $final_path "require -n flarum/core:'$flarum_version'"
+	exec_composer $app $final_path "require -n flarum/core:$flarum_version"
+	# Database password has to be input on admin page after upgrade to 0.1.0-beta.7.2
+	if [[ $flarum_version == "0.1.0-beta.7.2"]]; then
+		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd"
+	fi
 	pushd $final_path
 	exec_as $app php flarum cache:clear
 	popd
+	upgraded_flarum=true
 else
-	echo "Flarum doesn't need any update, let's check the extension."
+	echo "Flarum does not need to be updated."
+	upgraded_flarum=false
 fi
 
 # Check if upgrade of SSOwat extension is needed
@@ -132,6 +138,10 @@ if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver && echo t
 	ssowatdomain=$(</etc/yunohost/current_host)
 	sql_command="INSERT IGNORE INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
 	ynh_mysql_execute_as_root "$sql_command" $db_name
+	upgraded_ssowat=true
+else
+	echo "SSOwat extension does not need to be updated."
+        upgraded_ssowat=false
 fi
 
 if [ $bazaar_extension -eq 1 ]; then
@@ -213,5 +223,9 @@ systemctl reload nginx
 # STORE SETTINGS
 #===================================================
 
-ynh_app_setting_set $app flarum_version $flarum_version
-ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver
+if [ $upgraded_flarum ]; then
+	ynh_app_setting_set $app flarum_version $flarum_version
+fi
+if [ $upgraded_ssowat ]; then
+	ynh_app_setting_set $app ssowat_ext_ver $ssowat_ext_ver
+fi

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -120,8 +120,9 @@ if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version) ]]; then
 	pushd $final_path
 	exec_as $app php flarum cache:clear
 	popd
+	ynh_print_info "Flarum has been updated to version $flarum_version."
 else
-	echo "Flarum doesn't need any update, let's check the extension."
+	ynh_print_info "Flarum does not need updating."
 fi
 
 # Check if upgrade of SSOwat extension is needed
@@ -132,10 +133,14 @@ if [[ $(dpkg --compare-versions $old_ssowat_ext_ver lt $ssowat_ext_ver && echo t
 	ssowatdomain=$(</etc/yunohost/current_host)
 	sql_command="INSERT IGNORE INTO \`settings\` (\`key\`, \`value\`) VALUES ('tituspijean-auth-ssowat.domain', '$ssowatdomain'), ('tituspijean-auth-ssowat.onlyUse', '0');"
 	ynh_mysql_execute_as_root "$sql_command" $db_name
+	ynh_print_info "SSOwat extension has been updated and configured."
+else
+	ynh_print_info "SSOwat extension does not need updating."
 fi
 
 if [ $bazaar_extension -eq 1 ]; then
    install_and_activate_extension $app $final_path $db_name "flagrow/bazaar" "flagrow-bazaar"
+   ynh_print_info "Bazaar extension has been installed."
 fi
 
 #=================================================

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -118,8 +118,8 @@ if [[ $(dpkg --compare-versions $old_flarum_version lt $flarum_version && echo t
 	# Upgrade Flarum
 	exec_composer $app $final_path "require -n flarum/core:$flarum_version"
 	# Database password has to be input on admin page after upgrade to 0.1.0-beta.7.2
-	if [[ $flarum_version == "0.1.0-beta.7.2"]]; then
-		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd"
+	if [[ $flarum_version == "0.1.0-beta.7.2" ]]; then
+		curl "https://$domain$path_url/admin" -H "Accept: */*" --compressed -H "Content-Type: application/x-www-form-urlencoded; charset=UTF-8" --data "databasePassword=$db_pwd" -k
 	fi
 	pushd $final_path
 	exec_as $app php flarum cache:clear


### PR DESCRIPTION
🐛 **This is a security upgrade.**

Official documentation about this security fix requires the user to manually enter the password database in the /admin page. As it consists in a simple POST action, I used a curl call to automatically perform it.
⚠️ However, to perform this curl call with auto-signed certificates, I had to add the -k (accept all certificates) to the command. I consider the risk low, as the $domain curl reaches to is hosted by the same server.

---

While testing, I discovered some overlooks in the upgrade script that I fixed:
- check that upgrade actually occurred before upgrading the app's parameters
- fix the test logic for Flarum (was already fixed for the extension, we forgot to implement it some lines above)

---

I also added the new `ynh_print_*` helpers from a previous PR. 


---

Closes  #105 #102 #108.