### PR TITLE
Fix maintainer name spelling

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -11,7 +11,7 @@
     "license": "MIT",
     "version": "0.1.0-beta.7",
     "maintainer": {
-        "name": "Titus PiJean",
+        "name": "tituspijean",
         "email": "tituspijean@outlook.com"
     },
     "requirements": {


### PR DESCRIPTION
to be like:

- https://github.com/YunoHost-Apps/cowyo_ynh/blob/master/manifest.json
- https://github.com/YunoHost-Apps/grav_ynh/blob/master/manifest.json