### PR TITLE
[fix] Various fixes for CI

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -1,4 +1,4 @@
-location ^~ __PATH__ {
+location ^~ __PATH__/ {
 
     if ($scheme = http) {
 		rewrite ^ https://$server_name$request_uri? permanent;
@@ -23,25 +23,25 @@ location ^~ __PATH__ {
 
     # Expire rules for static content
     location ~* \.(?:manifest|appcache|html?|xml|json)$ {
-      add_header Cache-Control "max-age=0";
+      more_set_headers "Cache-Control: max-age=0";
     }
 
     location ~* \.(?:rss|atom)$ {
-      add_header Cache-Control "max-age=3600";
+      more_set_headers "Cache-Control: max-age=3600";
     }
 
     location ~* \.(?:jpg|jpeg|gif|png|ico|cur|gz|svg|mp4|ogg|ogv|webm|htc)$ {
-      add_header Cache-Control "max-age=2592000";
+      more_set_headers "Cache-Control: max-age=2592000";
       access_log off;
     }
 
     location ~* \.(?:css|js)$ {
-      add_header Cache-Control "max-age=31536000";
+      more_set_headers "Cache-Control: max-age=31536000";
       access_log off;
     }
 
     location ~* \.(?:ttf|ttc|otf|eot|woff|woff2)$ {
-      add_header Cache-Control "max-age=2592000";
+      more_set_headers "Cache-Control: max-age=2592000";
       access_log off;
     }
 

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,6 @@
     "multi_instance": true,
     "services": [
         "nginx",
-        "php7.3-fpm",
         "mysql"
     ],
     "arguments": {
@@ -73,6 +72,10 @@
                     "en": "Is it a public application?",
                     "fr": "Est-ce une application publique ?",
                     "de": "Ist es eine öffentliche Applikation ?"
+                },
+                "help": {
+                    "en": "If public, it will be open to all visitors like any forum. If private, only the YunoHost server users can access it.",
+                    "fr": "Si public, le forum sera accessible à tous, comme pour tout forum. Si privé, seuls les utilisateurs du serveur YunoHost pourront y accéder."
                 },
                 "default": true
             },


### PR DESCRIPTION
- [x] Do not use 'add_header' in the nginx conf.
- [x] The nginx configuration appears vulnerable to path traversal
- [x] [YEP-2.1?] php7.3-fpm service not installed by the install file but present in the manifest
- [x] Consider adding an 'help' key for argument 'is_public'
- [ ] ~~[YEP-2.4] 'ynh_die' or 'exit' command is executed with system modification before (cmd 'apt').~~ Most likely due to the experimental helpers to install PHP7.3. The `apt` calls are in functions, and called later in the script.
- [ ] ~~Some lines could not be parsed in script install.~~ All good, those are multi-line strings.