### PR TITLE
Various enhancements (old helper, composer warning, language extension)

### DIFF
--- a/scripts/experimental_helpers/ynh_composer__2
+++ b/scripts/experimental_helpers/ynh_composer__2
@@ -2,42 +2,48 @@
 
 # Execute a command with Composer
 #
-# usage: ynh_composer_exec [--phpversion=phpversion] [--workdir=$final_path] --commands="commands"
-# | arg: -v, --phpversion - PHP version to use with composer
+# usage: ynh_composer_exec [--user=app] [--phpversion=phpversion] [--workdir=$final_path] --commands="commands"
+# | arg: -u, --user - User to execute composer with.
+# | arg: -v, --phpversion - PHP version to use with composer.
 # | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
 # | arg: -c, --commands - Commands to execute.
 ynh_composer_exec () {
 	# Declare an array to define the options of this helper.
-	local legacy_args=vwc
-	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [c]=commands= )
+	local legacy_args=uvwc
+	declare -Ar args_array=( [u]=user= [v]=phpversion= [w]=workdir= [c]=commands= )
+	local user
 	local phpversion
 	local workdir
 	local commands
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
+	user="${user:-$app}"
 	workdir="${workdir:-$final_path}"
 	phpversion="${phpversion:-$YNH_PHP_VERSION}"
 
 	COMPOSER_HOME="$workdir/.composer" \
-		php${phpversion} "$workdir/composer.phar" $commands \
+		exec_as $user php${phpversion} "$workdir/composer.phar" $commands \
 		-d "$workdir" --no-interaction
 }
 
 # Install and initialize Composer in the given directory
 #
 # usage: ynh_install_composer [--phpversion=phpversion] [--workdir=$final_path] [--install_args="--optimize-autoloader"]
+# | arg: -u, --user - User to execute composer with.
 # | arg: -v, --phpversion - PHP version to use with composer
 # | arg: -w, --workdir - The directory from where the command will be executed. Default $final_path.
 # | arg: -a, --install_args - Additional arguments provided to the composer install. Argument --no-dev already include
 ynh_install_composer () {
 	# Declare an array to define the options of this helper.
 	local legacy_args=vwa
-	declare -Ar args_array=( [v]=phpversion= [w]=workdir= [a]=install_args=)
+	declare -Ar args_array=( [u]=user= [v]=phpversion= [w]=workdir= [a]=install_args=)
+	local user
 	local phpversion
 	local workdir
 	local install_args
 	# Manage arguments with getopts
 	ynh_handle_getopts_args "$@"
+	user="${user:-$app}"
 	workdir="${workdir:-$final_path}"
 	phpversion="${phpversion:-$YNH_PHP_VERSION}"
 	install_args="${install_args:-}"
@@ -47,7 +53,10 @@ ynh_install_composer () {
 		php${phpversion} -- --install-dir="$workdir" \
 		|| ynh_die "Unable to install Composer."
 
+	# Making sure workdir is writable
+	chown -R $user: $workdir
+
 	# update dependencies to create composer.lock
-	ynh_composer_exec --phpversion="${phpversion}" --workdir="$workdir" --commands="install --no-dev $install_args" \
+	ynh_composer_exec --user=$user --phpversion="${phpversion}" --workdir="$workdir" --commands="install --no-dev $install_args" \
 		|| ynh_die "Unable to update core dependencies with Composer."
 }

--- a/scripts/experimental_helpers/ynh_send_readme_to_admin
+++ b/scripts/experimental_helpers/ynh_send_readme_to_admin
@@ -1,30 +1,24 @@
 #!/bin/bash
 
+# Need also the helper https://github.com/YunoHost-Apps/Experimental_helpers/blob/master/ynh_handle_getopts_args/ynh_handle_getopts_args
+
 # Send an email to inform the administrator
 #
-# usage: ynh_send_readme_to_admin --app_message=app_message [--recipients=recipients] [--type=type]
-# | arg: -m --app_message= - The file with the content to send to the administrator.
+# usage: ynh_send_readme_to_admin app_message [recipients]
+# | arg: -m --app_message= - The message to send to the administrator.
 # | arg: -r, --recipients= - The recipients of this email. Use spaces to separate multiples recipients. - default: root
 #	example: "root admin@domain"
 #	If you give the name of a YunoHost user, ynh_send_readme_to_admin will find its email adress for you
 #	example: "root admin@domain user1 user2"
-# | arg: -t, --type= - Type of mail, could be 'backup', 'change_url', 'install', 'remove', 'restore', 'upgrade'
 ynh_send_readme_to_admin() {
 	# Declare an array to define the options of this helper.
-	declare -Ar args_array=( [m]=app_message= [r]=recipients= [t]=type= )
+	declare -Ar args_array=( [m]=app_message= [r]=recipients= )
 	local app_message
 	local recipients
-	local type
 	# Manage arguments with getopts
-
 	ynh_handle_getopts_args "$@"
-	app_message="${app_message:-}"
-	recipients="${recipients:-root}"
-	type="${type:-install}"
-
-	# Get the value of admin_mail_html
-	admin_mail_html=$(ynh_app_setting_get $app admin_mail_html)
-	admin_mail_html="${admin_mail_html:-0}"
+	local app_message="${app_message:-...No specific information...}"
+	local recipients="${recipients:-root}"
 
 	# Retrieve the email of users
 	find_mails () {
@@ -50,75 +44,15 @@ ynh_send_readme_to_admin() {
 	}
 	recipients=$(find_mails "$recipients")
 
-	# Subject base
-	local mail_subject="☁️🆈🅽🅷☁️: \`$app\`"
-
-	# Adapt the subject according to the type of mail required.
-	if [ "$type" = "backup" ]; then
-		mail_subject="$mail_subject has just been backup."
-	elif [ "$type" = "change_url" ]; then
-		mail_subject="$mail_subject has just been moved to a new URL!"
-	elif [ "$type" = "remove" ]; then
-		mail_subject="$mail_subject has just been removed!"
-	elif [ "$type" = "restore" ]; then
-		mail_subject="$mail_subject has just been restored!"
-	elif [ "$type" = "upgrade" ]; then
-		mail_subject="$mail_subject has just been upgraded!"
-	else	# install
-		mail_subject="$mail_subject has just been installed!"
-	fi
+	local mail_subject="☁️🆈🅽🅷☁️: \`$app\` was just installed!"
 
 	local mail_message="This is an automated message from your beloved YunoHost server.
 
 Specific information for the application $app.
 
-$(if [ -n "$app_message" ]
-then
-	cat "$app_message"
-else
-	echo "...No specific information..."
-fi)
+$app_message
 
----
-Automatic diagnosis data from YunoHost
-
-__PRE_TAG1__$(yunohost tools diagnosis | grep -B 100 "services:" | sed '/services:/d')__PRE_TAG2__"
-
-	# Store the message into a file for further modifications.
-	echo "$mail_message" > mail_to_send
-
-	# If a html email is required. Apply html tags to the message.
- 	if [ "$admin_mail_html" -eq 1 ]
- 	then
-		# Insert 'br' tags at each ending of lines.
-		ynh_replace_string "$" "<br>" mail_to_send
-
-		# Insert starting HTML tags
-		sed --in-place '1s@^@<!DOCTYPE html>\n<html>\n<head></head>\n<body>\n@' mail_to_send
-
-		# Keep tabulations
-		ynh_replace_string "  " "\&#160;\&#160;" mail_to_send
-		ynh_replace_string "\t" "\&#160;\&#160;" mail_to_send
-
-		# Insert url links tags
-		ynh_replace_string "__URL_TAG1__\(.*\)__URL_TAG2__\(.*\)__URL_TAG3__" "<a href=\"\2\">\1</a>" mail_to_send
-
-		# Insert pre tags
-		ynh_replace_string "__PRE_TAG1__" "<pre>" mail_to_send
-		ynh_replace_string "__PRE_TAG2__" "<\pre>" mail_to_send
-
-		# Insert finishing HTML tags
-		echo -e "\n</body>\n</html>" >> mail_to_send
-
-	# Otherwise, remove tags to keep a plain text.
-	else
-		# Remove URL tags
-		ynh_replace_string "__URL_TAG[1,3]__" "" mail_to_send
-		ynh_replace_string "__URL_TAG2__" ": " mail_to_send
-
-		# Remove PRE tags
-		ynh_replace_string "__PRE_TAG[1-2]__" "" mail_to_send
-	fi
+"
 
 	# Define binary to use for mail command
 	if [ -e /usr/bin/bsd-mailx ]
@@ -128,13 +62,6 @@ __PRE_TAG1__$(yunohost tools diagnosis | grep -B 100 "services:" | sed '/service
 		local mail_bin=/usr/bin/mail.mailutils
 	fi
 
-	if [ "$admin_mail_html" -eq 1 ]
-	then
-		content_type="text/html"
-	else
-		content_type="text/plain"
-	fi
-
 	# Send the email to the recipients
-	cat mail_to_send | $mail_bin -a "Content-Type: $content_type; charset=UTF-8" -s "$mail_subject" "$recipients"
+	echo "$mail_message" | $mail_bin -a "Content-Type: text/plain; charset=UTF-8" -s "$mail_subject" "$recipients"
 }

--- a/scripts/install
+++ b/scripts/install
@@ -201,8 +201,8 @@ ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require milescellar/lang-french"
-    activate_flarum_extension $db_name "milescellar-lang-french"
+    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
+    activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
     ;;

--- a/scripts/install
+++ b/scripts/install
@@ -141,24 +141,21 @@ ynh_add_swap --size=$swap_needed
 #=================================================
 ynh_script_progression --message="Installing composer dependencies..."
 
-ynh_exec_warn_less ynh_install_composer --phpversion="$phpversion" --workdir="$final_path"
+ynh_exec_warn_less ynh_install_composer --user=$app --phpversion="$phpversion" --workdir="$final_path"
 
 # Set Flarum version
-ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-lowest --no-update"
+ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-lowest --no-update"
 
 # Require SSOwat extension
-ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ssowat:$ssowat_version --no-update"
+ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ssowat:$ssowat_version --no-update"
 
 # Update and download dependencies
-ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="update"
+ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="update"
 
 #=================================================
 # FLARUM POST-INSTALL
 #=================================================
 ynh_script_progression --message="Configuring Flarum..." --weight=2
-
-# Making sure it is writable
-chown -R $app: $final_path
 
 # Copy the configuration.yml to working directory
 finalflarumconf="$final_path/configuration.yml"
@@ -201,14 +198,14 @@ ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
+    ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
     activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
     ;;
   de)
     ynh_script_progression --message="Installing German extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require cbmainz/flarum-de"
+    ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require cbmainz/flarum-de"
     activate_flarum_extension $db_name "cbmainz-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name

--- a/scripts/install
+++ b/scripts/install
@@ -261,8 +261,8 @@ ynh_script_progression --message="Sending generated admin credentials by email, 
 app_message="User : $admin, password : $admin_pwd
 Change your password!
 Your forum is accessible at https://$domain$path_url"
-ynh_send_readme_to_admin "$app_message" "$admin"
-ynh_print_warn "$app_message"
+ynh_send_readme_to_admin --app_message=$app_message --recipients=$admin
+ynh_print_warn --message=$app_message
 
 #=================================================
 # END OF SCRIPT

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -217,13 +217,13 @@ then
 	chown -R $app:www-data $final_path
 
 	# Install Composer and Flarum
-	ynh_install_composer --phpversion=$phpversion --workdir=$final_path
+	ynh_install_composer --user=$app --phpversion=$phpversion --workdir=$final_path
 
 	# Perform migrations and clear cache
 	pushd $final_path
 		ynh_script_progression --message="Upgrading Flarum and its extensions..." --weight=1
-		ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ssowat:$ssowat_version --no-update"
-		ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-dist --update-no-dev -a --update-with-all-dependencies"
+		ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ssowat:$ssowat_version --no-update"
+		ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-dist --update-no-dev -a --update-with-all-dependencies"
 		exec_as $app php$phpversion flarum migrate
 		exec_as $app php$phpversion flarum cache:clear
 	popd
@@ -247,14 +247,14 @@ fi
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
+    ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
     activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name
     ;;
   de)
     ynh_script_progression --message="Installing German extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require cbmainz/flarum-de"
+    ynh_composer_exec --user=$app --phpversion=$phpversion --workdir=$final_path --commands="require cbmainz/flarum-de"
     activate_flarum_extension $db_name "cbmainz-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -133,16 +133,16 @@ then
 	# Create a temporary directory
 	tmpdir="$(mktemp -d)"
 	cp -R $final_path/* $tmpdir
-	
+
 	# Deleting current app directory
 	ynh_secure_remove --file="$final_path"
-	
+
 	# Download, check integrity, uncompress and patch the source from app.src
 	ynh_setup_source --dest_dir="$final_path"
-	
+
 	# Copy config.php back into Flarum
 	cp -f $tmpdir/config.php $final_path
-	
+
 	# Copy assets from old app version. Can be either in root folder or in "public" folder
 	if [ -d $tmpdir/assets ]; then
 		cp -Rf $tmpdir/assets $final_path/public
@@ -247,8 +247,8 @@ fi
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require milescellar/lang-french"
-    activate_flarum_extension $db_name "milescellar-lang-french"
+    ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french"
+    activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root "$sql_command" $db_name
     ;;


### PR DESCRIPTION
## Problem
See #147 :
- [x] ynh_send_readme_to_admin is not up-to-date with latest `yunohost diagnosis` command
- [x] Composer displays warnings about being run with `root`
- [x] `qiaeru/lang-french` is now the French language extension

## Solution
Closes #147 
- Upgrade helper but remove the diagnosis command (not really useful here)
- Composer helper has been upgraded (again) with a `--user` parameter
- The advised extension is now used

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/flarum_ynh%20PR148%20(tituspijean)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/flarum_ynh%20PR148%20(tituspijean)/)  

Test in my own package_check instance : [Level 7](https://paste.yunohost.org/evacopihur.coffeescript)
