### PR TITLE
[fix] ssowat extension version

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,7 +14,7 @@ extra_php_dependencies="php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-dom php
 # Version numbers
 project_version="~0.1.0-beta.13"
 core_version="~0.1.0-beta.13"
-ssowat_version="dev-0.1.0-beta.13"
+ssowat_version="~0.1.0-beta.13"
 
 #=================================================
 # PERSONAL HELPERS


### PR DESCRIPTION
## Problem
- Bad version naming for ssowat extension leads to installation failure.

## Solution
- `dev-0.1.0-beta.13` becomes `~0.1.0-beta.13`

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested.
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
https://ci-apps-dev.yunohost.org/jenkins/job/flarum_ynh%20(tituspijean)/71/

*Will most likely fail, but we only want to check that it installs, at least...*
