### PR TITLE
Increases client_max_body_size to allow file upload

### DIFF
--- a/conf/nginx.conf
+++ b/conf/nginx.conf
@@ -79,6 +79,9 @@ location __PATH__/ {
         text/x-component
         text/x-cross-domain-policy;
 
+    # Allows file upload, e.g. fof/upload.
+    client_max_body_size 100M;
+
   # Include SSOWAT user panel.
   # include conf.d/yunohost_panel.conf.inc;
 }

--- a/conf/php-fpm.conf
+++ b/conf/php-fpm.conf
@@ -419,8 +419,8 @@ catch_workers_output = yes
 ;php_admin_value[memory_limit] = 32M
 
 ; Common values to change to increase file upload limit
-; php_admin_value[upload_max_filesize] = 50M
-; php_admin_value[post_max_size] = 50M
+php_admin_value[upload_max_filesize] = 100M
+php_admin_value[post_max_size] = 100M
 ; php_admin_flag[mail.add_x_header] = Off
 
 ; Other common parameters


### PR DESCRIPTION
## Problem
`fof/upload` has a setting to limit the size of files to be uploaded.
However, nginx max default is 1M so even if we increase the size limit in the settings of the extension, nginx doesn't allow more than 1M. 


## Solution

Increases `client_max_body_size` to 100M in nginx.
Finer control is done by the extension.

## PR Status
- [x] Code finished.
- [x] Tested with Package_check.
- [x] Fix or enhancement tested. (on my own server, hubesco.com/wath)
- [x] Upgrade from last version tested.
- [x] Can be reviewed and tested.

## Package_check results
---
```
Debian GNU/Linux 10
yunohost:
  repo: stable
  version: 4.1.6
yunohost-admin:
  repo: stable
  version: 4.1.4
moulinette:
  repo: stable
  version: 4.1.4
ssowat:
  repo: stable
  version: 4.1.3
```

<img width="1160" alt="Screenshot 2021-01-23 at 20 11 37" src="https://user-images.githubusercontent.com/1893985/105612961-646a0480-5db7-11eb-87c7-72e52982f0cf.png">
