### PR TITLE
Fix SQL templates and use Composer 2

### DIFF
--- a/conf/ldap.sql.template
+++ b/conf/ldap.sql.template
@@ -2,7 +2,7 @@ INSERT INTO `settings` (`key`, `value`) VALUES
 ('tituspijean-auth-ldap.admin_dn', ''),
 ('tituspijean-auth-ldap.admin_password', ''),
 ('tituspijean-auth-ldap.base_dn', 'ou=users,dc=yunohost,dc=org'),
-('tituspijean-auth-ldap.filter', '(&(objectClass=posixAccount)(permission=cn=flarum.main,ou=permission,dc=yunohost,dc=org))'),
+('tituspijean-auth-ldap.filter', '(&(objectClass=posixAccount)(permission=cn=__APP__.main,ou=permission,dc=yunohost,dc=org))'),
 ('tituspijean-auth-ldap.follow_referrals', '0'),
 ('tituspijean-auth-ldap.hosts', 'localhost'),
 ('tituspijean-auth-ldap.method_name', 'YunoHost'),

--- a/conf/mail.sql.template
+++ b/conf/mail.sql.template
@@ -1,7 +1,7 @@
 INSERT INTO `settings` (`key`, `value`) VALUES
   ('mail_driver', 'mail'),
   ('mail_encryption', 'ssl'),
-  ('mail_from', '$app@$domain'),
+  ('mail_from', '__APP__@__DOMAIN__'),
   ('mail_host', 'localhost'),
   ('mail_port', '587')
 ON DUPLICATE KEY UPDATE value = VALUES(value);

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
         "fr": "Un forum de nouvelle génération, simplement.",
         "de": "Forum der nächsten Generation leicht gemacht."
     },
-    "version": "0.1.0.16~ynh1",
+    "version": "0.1.0.16~ynh2",
     "url": "http://flarum.org/",
     "license": "MIT",
     "maintainer": {

--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -13,6 +13,6 @@
 
 ## Package_check results
 ---
-*If you have access to [App Continuous Integration for packagers](https://yunohost.org/#/packaging_apps_ci) you can provide a link to the package_check results like below, replacing '-NUM-' in this link by the PR number and USERNAME by your username on the ci-apps-dev. Or you provide a screenshot or a pastebin of the results*
+* An automatic package_check will be launch at https://ci-apps-dev.yunohost.org/, when you add a specific comment to your Pull Request: "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!"*
 
-[![Build Status](https://ci-apps-dev.yunohost.org/jenkins/job/flarum_ynh%20PR-NUM-%20(USERNAME)/badge/icon)](https://ci-apps-dev.yunohost.org/jenkins/job/flarum_ynh%20PR-NUM-%20(USERNAME)/)  
+

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -8,6 +8,8 @@ pkg_dependencies=""
 swap_needed=1024
 
 YNH_PHP_VERSION="7.3"
+YNH_COMPOSER_VERSION="2.0.13"
+
 
 extra_php_dependencies="php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-dom php${YNH_PHP_VERSION}-gd php${YNH_PHP_VERSION}-json php${YNH_PHP_VERSION}-mbstring php${YNH_PHP_VERSION}-pdo-mysql php${YNH_PHP_VERSION}-tokenizer php${YNH_PHP_VERSION}-zip"
 

--- a/scripts/install
+++ b/scripts/install
@@ -168,11 +168,13 @@ pushd $final_path
 popd
 
 # Email setup
+ynh_add_config --template="../conf/mail.sql.template" --destination="../conf/mail.sql"
 ynh_mysql_connect_as --user=$app --password="$db_pwd" --database=$db_name < ../conf/mail.sql
 
 # Enable and set up the LDAP auth extension
 ynh_script_progression --message="Enabling and configuring LDAP extension..." --weight=2
 activate_flarum_extension $db_name "tituspijean-auth-ldap"
+ynh_add_config --template="../conf/ldap.sql.template" --destination="../conf/ldap.sql"
 ynh_mysql_connect_as --user=$app --password="$db_pwd" --database=$db_name < ../conf/ldap.sql
 
 # Install, activate and set language extensions

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -202,6 +202,7 @@ then
 	# Install and activate the LDAP auth extension
 	activate_flarum_extension $db_name "tituspijean-auth-ldap"
 	# Configure LDAP auth extension
+	ynh_add_config --template="../conf/ldap.sql.template" --destination="../conf/ldap.sql"
 	ynh_mysql_connect_as --user=$app --password="$db_pwd" --database=$db_name < ../conf/ldap.sql
 fi
 


### PR DESCRIPTION
## Problem
- Composer 2 is *much* faster than v1
- Variables in SQL files were not being replaced

## Solution
- Let's use latest Composer version
- Use `ynh_add_config` to update SQL templates before running them.

## CI tests

[![Test Badge](https://img.shields.io/endpoint?url=https://ci.pijean.ovh/ci/api/job/17/badge)](https://ci.pijean.ovh/ci/job/17)
