### PR TITLE
Fix ynh_composer_exec syntax and upgrade to v1.1.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ If you don't have YunoHost, please consult [the guide](https://yunohost.org/#/in
 
 Flarum is a simple discussion platform for your website. It's fast and easy to use, with all the features you need to run a successful community.
 
-**Shipped version:** 1.0.0~ynh6
+**Shipped version:** 1.1.1~ynh1
 
 **Demo:** https://discuss.flarum.org/d/21101-demos-come-to-flarum
 

--- a/README_fr.md
+++ b/README_fr.md
@@ -13,7 +13,7 @@ Si vous n'avez pas YunoHost, regardez [ici](https://yunohost.org/#/install) pour
 
 Flarum est une plate-forme de discussion simple pour votre site Web. C'est rapide et facile à utiliser, avec toutes les fonctionnalités dont vous avez besoin pour gérer une communauté.
 
-**Version incluse :** 1.0.0~ynh6
+**Version incluse :** 1.1.1~ynh1
 
 **Démo :** https://discuss.flarum.org/d/21101-demos-come-to-flarum
 

--- a/check_process
+++ b/check_process
@@ -19,6 +19,7 @@
 #		upgrade=1	from_commit=0d30809a2903544a660635f62a25bc6057ea2f15
 #		upgrade=1	from_commit=0175b7a3b0a551e14f39c65290d194ccc71cd6ee
 #		upgrade=1	from_commit=70e962faa875070b0fcc29f45cc70e2a51de76a6
+		upgrade=1	from_commit=b6a29ea2bb4c3d2b5aa2dd786d12b72844e88929
 		backup_restore=1
 		multi_instance=1
 		port_already_use=0
@@ -35,4 +36,7 @@ Notification=none
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&password=PASSWORD&language=fr&is_public=1&title=Forum&
 	; commit=70e962faa875070b0fcc29f45cc70e2a51de76a6
 		name=2021-05-06 0.1.0.16~ynh2
+		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&password=PASSWORD&language=fr&is_public=1&title=Forum&
+	; commit=b6a29ea2bb4c3d2b5aa2dd786d12b72844e88929
+		name=2021-11-12 fixed 1.0
 		manifest_arg=domain=DOMAIN&path=PATH&admin=USER&password=PASSWORD&language=fr&is_public=1&title=Forum&

--- a/manifest.json
+++ b/manifest.json
@@ -7,7 +7,7 @@
         "fr": "Forum de nouvelle génération, simplement",
         "de": "Forum der nächsten Generation leicht gemacht"
     },
-    "version": "1.0.0~ynh6",
+    "version": "1.1.1~ynh1",
     "url": "http://flarum.org/",
     "upstream": {
         "license": "MIT",

--- a/manifest.json
+++ b/manifest.json
@@ -60,8 +60,7 @@
                 "help": {
                     "en": "Choose your password. It will be useful if logging in from YunoHost fails or is disrupted.",
                     "fr": "Choisissez votre mot de passe. Il sera utile si la connexion via YunoHost échoue ou est perturbée."
-                },
-                "example": "Choose a password"
+                }
             },
             {
                 "name": "title",

--- a/manifest.json
+++ b/manifest.json
@@ -22,7 +22,7 @@
         "email": "tituspijean@outlook.com"
     },
     "requirements": {
-        "yunohost": ">= 4.2.0"
+        "yunohost": ">= 4.3.2"
     },
     "multi_instance": true,
     "services": [

--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -14,8 +14,8 @@ extra_php_dependencies="php${YNH_PHP_VERSION}-curl php${YNH_PHP_VERSION}-dom php
 
 # Version numbers
 project_version="~1.0.0"
-core_version="~1.0.0"
-ldap_version="~1.0.0-p1"
+#core_version is now retrieved from the manifest
+ldap_version="*"
 
 #=================================================
 # PERSONAL HELPERS

--- a/scripts/install
+++ b/scripts/install
@@ -53,13 +53,13 @@ ynh_webpath_register --app=$app --domain=$domain --path_url=$path_url
 #=================================================
 ynh_script_progression --message="Storing installation settings..."
 
-ynh_app_setting_set --app=$app --key=domain --value=$domain
-ynh_app_setting_set --app=$app --key=path --value=$path_url
-ynh_app_setting_set --app=$app --key=admin --value=$admin
-ynh_app_setting_set --app=$app --key=language --value=$language
-ynh_app_setting_set --app=$app --key=project_version --value=$project_version
-ynh_app_setting_set --app=$app --key=core_version --value=$core_version
-ynh_app_setting_set --app=$app --key=ldap_version --value=$ldap_version
+ynh_app_setting_set --app=$app --key=domain --value="$domain"
+ynh_app_setting_set --app=$app --key=path --value="$path_url"
+ynh_app_setting_set --app=$app --key=admin --value="$admin"
+ynh_app_setting_set --app=$app --key=language --value="$language"
+ynh_app_setting_set --app=$app --key=project_version --value="$project_version"
+ynh_app_setting_set --app=$app --key=core_version --value="$core_version"
+ynh_app_setting_set --app=$app --key=ldap_version --value="$ldap_version"
 
 #=================================================
 # STANDARD MODIFICATIONS

--- a/scripts/install
+++ b/scripts/install
@@ -172,14 +172,14 @@ ynh_mysql_connect_as --user=$app --password="$db_pwd" --database=$db_name < ../c
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require qiaeru/lang-french:^2.0.0\"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french:^2.0.0"
     activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
     ;;
   de)
     ynh_script_progression --message="Installing German extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require kakifrucht/flarum-de:^1.0.0\"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require kakifrucht/flarum-de:^1.0.0"
     activate_flarum_extension $db_name "kakifrucht-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name

--- a/scripts/install
+++ b/scripts/install
@@ -31,6 +31,7 @@ admin_pwd=$YNH_APP_ARG_PASSWORD
 is_public=$YNH_APP_ARG_IS_PUBLIC
 language=$YNH_APP_ARG_LANGUAGE
 title=$YNH_APP_ARG_TITLE
+core_version=$(ynh_app_upstream_version)
 
 admin_mail=$(ynh_user_get_info --username=$admin --key=mail)
 

--- a/scripts/install
+++ b/scripts/install
@@ -135,13 +135,13 @@ ynh_script_progression --message="Installing composer dependencies..." --weight=
 ynh_exec_warn_less ynh_install_composer --phpversion="$phpversion" --workdir="$final_path"
 
 # Set Flarum version
-ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require flarum/core:$core_version --prefer-lowest --no-update\"
+ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-lowest --no-update"
 
 # Require LDAP extension
-ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require tituspijean/flarum-ext-auth-ldap:$ldap_version --no-update\"
+ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ldap:$ldap_version --no-update"
 
 # Update and download dependencies
-ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"update\"
+ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="update"
 
 #=================================================
 # FLARUM POST-INSTALL

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -184,7 +184,8 @@ then
 	# Install Composer and Flarum
 	ynh_exec_warn_less ynh_install_composer --phpversion=$phpversion --workdir=$final_path
 
-	if [ ynh_compare_current_package_version --comparison lt --version 1.1.0~ynh1 ]; then
+	if ynh_compare_current_package_version --comparison lt --version 1.1.0~ynh1
+	then
 		# Starting 1.0 (implemented for 1.1 in the package), version requirement is "*" for extensions
 		# ... except for flarum/core, but that's handled in the next block.
 		jq '.require | .[] = "*"' $final_path/composer.json

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -87,7 +87,7 @@ fi
 # Remove SSOwat if it exists
 ssowat_extension=$(ynh_app_setting_get --app=$app --key=ssowat_extension)
 if [ ! -z "$ssowat_extension" ]; then
-	ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"remove tituspijean/flarum-ext-auth-ssowat\"
+	ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="remove tituspijean/flarum-ext-auth-ssowat"
 	ynh_app_setting_delete --app=$app --key=ssowat_extension
 fi
 
@@ -186,8 +186,8 @@ then
 	# Perform migrations and clear cache
 	pushd $final_path
 		ynh_script_progression --message="Upgrading Flarum and its extensions..." --weight=1
-		ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require tituspijean/flarum-ext-auth-ldap:$ldap_version --no-update\"
-		ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require flarum/core:$core_version --prefer-dist --update-no-dev -a --update-with-all-dependencies\"
+		ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require tituspijean/flarum-ext-auth-ldap:$ldap_version --no-update"
+		ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require flarum/core:$core_version --prefer-dist --update-no-dev -a --update-with-all-dependencies"
 		ynh_exec_as $app php$phpversion flarum migrate
 		ynh_exec_as $app php$phpversion flarum cache:clear
 	popd
@@ -210,14 +210,14 @@ fi
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require qiaeru/lang-french:^2.0.0\"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french:^2.0.0"
     activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
     ;;
   de)
     ynh_script_progression --message="Installing German extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands=\"require kakifrucht/flarum-de:^1.0.0\"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require kakifrucht/flarum-de:^1.0.0"
     activate_flarum_extension $db_name "kakifrucht-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -240,9 +240,9 @@ pushd $final_path
 popd
 
 # Save version settings
-ynh_app_setting_set $app project_version $project_version
-ynh_app_setting_set $app core_version $core_version
-ynh_app_setting_set $app ldap_version $ldap_version
+ynh_app_setting_set $app project_version "$project_version"
+ynh_app_setting_set $app core_version "$core_version"
+ynh_app_setting_set $app ldap_version "$ldap_version"
 
 #=================================================
 # GENERIC FINALIZATION

--- a/scripts/upgrade
+++ b/scripts/upgrade
@@ -26,6 +26,7 @@ db_name=$(ynh_app_setting_get --app=$app --key=db_name)
 db_pwd=$(ynh_app_setting_get --app=$app --key=db_pwd)
 old_project_version=$(ynh_app_setting_get --app=$app --key=project_version)
 old_core_version=$(ynh_app_setting_get --app=$app --key=core_version)
+core_version=$(ynh_app_upstream_version)
 old_ldap_version=$(ynh_app_setting_get --app=$app --key=ldap_version)
 
 #=================================================
@@ -84,7 +85,7 @@ if [ ! -z "$bazaar_extension" ]; then
 	ynh_app_setting_delete --app=$app --key=bazaar_extension
 fi
 
-# Remove SSOwat if it exists
+# Remove SSOwat extension if it exists
 ssowat_extension=$(ynh_app_setting_get --app=$app --key=ssowat_extension)
 if [ ! -z "$ssowat_extension" ]; then
 	ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="remove tituspijean/flarum-ext-auth-ssowat"
@@ -183,6 +184,12 @@ then
 	# Install Composer and Flarum
 	ynh_exec_warn_less ynh_install_composer --phpversion=$phpversion --workdir=$final_path
 
+	if [ ynh_compare_current_package_version --comparison lt --version 1.1.0~ynh1 ]; then
+		# Starting 1.0 (implemented for 1.1 in the package), version requirement is "*" for extensions
+		# ... except for flarum/core, but that's handled in the next block.
+		jq '.require | .[] = "*"' $final_path/composer.json
+	fi
+
 	# Perform migrations and clear cache
 	pushd $final_path
 		ynh_script_progression --message="Upgrading Flarum and its extensions..." --weight=1
@@ -210,14 +217,14 @@ fi
 case $language in
   fr)
     ynh_script_progression --message="Installing French extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french:^2.0.0"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require qiaeru/lang-french:*"
     activate_flarum_extension $db_name "qiaeru-lang-french"
     sql_command="UPDATE \`settings\` SET \`value\` = 'fr' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name
     ;;
   de)
     ynh_script_progression --message="Installing German extension..." --weight=2
-    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require kakifrucht/flarum-de:^1.0.0"
+    ynh_exec_warn_less ynh_composer_exec --phpversion=$phpversion --workdir=$final_path --commands="require kakifrucht/flarum-de:*"
     activate_flarum_extension $db_name "kakifrucht-de"
     sql_command="UPDATE \`settings\` SET \`value\` = 'de' WHERE \`settings\`.\`key\` = 'default_locale'"
     ynh_mysql_execute_as_root --sql="$sql_command" --database=$db_name


### PR DESCRIPTION
## Problem

. c.f. https://forum.yunohost.org/t/app-flarum-installation-echouee-une-erreur-est-survenue-dans-le-script-dinstallation-de-lapplication/17738

## Solution

- Issue is probably related to the fact that ynh_exec_* was doing an eval and doesn't anymore ...

## PR Status

- [ ] Code finished and ready to be reviewed/tested
- [ ] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
